### PR TITLE
fixed auto scroll to tabs & active line

### DIFF
--- a/src/components/search-menu.tsx
+++ b/src/components/search-menu.tsx
@@ -20,8 +20,11 @@ const SearchMenu: FunctionComponent = () => {
 
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearch(e.target.value);
+    // If search is empty
+    if (!e.target.value) return setFoundGroupedArray(undefined);
+    // Search files
     const foundFiles = searchFiles(e.target.value, documents);
-
+    // Group files
     const groupedArray = foundFiles.reduce((acc, curr) => {
       const { title } = curr.file;
       if (!acc[title]) {
@@ -30,8 +33,8 @@ const SearchMenu: FunctionComponent = () => {
       acc[title]?.push(curr);
       return acc;
     }, {} as { [key: string]: typeof foundFiles });
-
-    setFoundGroupedArray(groupedArray);
+    // Set found grouped array
+    return setFoundGroupedArray(groupedArray);
   };
 
   return (
@@ -51,7 +54,7 @@ const SearchMenu: FunctionComponent = () => {
       {/* Documents */}
       <div className="h-full overflow-hidden">
         <SimpleBar className="h-full w-full">
-          <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
             {foundGroupedArray &&
               Object.keys(foundGroupedArray).map((key) => (
                 <TreeView key={key} title={key} childs={foundGroupedArray[key]} />

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -17,7 +17,7 @@ interface ITabsProps {
 
 const Tabs: FunctionComponent<ITabsProps> = ({ title }) => {
   // Scrollable node ref
-  const scrollableNodeRef = createRef();
+  const scrollableNodeRef = createRef<HTMLElement>();
   // Active tabs
   const activeTabs = useDocumentsStore((state) => state.activeTabs);
   const removeActiveTab = useDocumentsStore((state) => state.removeActiveTab);
@@ -25,21 +25,21 @@ const Tabs: FunctionComponent<ITabsProps> = ({ title }) => {
   const activeFile = useDocumentsStore((state) => state.activeFile);
   const findActiveFile = useDocumentsStore((state) => state.findActiveFile);
   const setActiveFile = useDocumentsStore((state) => state.setActiveFile);
-  // Show menu
-  const showMenu = useDocumentsStore((state) => state.showMenu);
   // Run component
   const runComponent = useDocumentsStore((state) => state.runComponent);
   const setRunComponent = useDocumentsStore((state) => state.setRunComponent);
 
   // Handle scroll position
   useEffect(() => {
+    // Get the scrollable node and the active tab
+    const scrollElement = scrollableNodeRef.current;
     const activeTabElement = document.getElementById(activeFile.toString());
-    activeTabElement?.scrollIntoView({
-      block: 'start',
-      behavior: 'smooth',
-    });
-    console.log('asd');
-  }, [activeFile, showMenu]);
+    // If there is no scrollable node or active tab, return
+    if (!activeTabElement || !scrollElement) return;
+    // Scroll to the active tab
+    const left = activeTabElement.offsetLeft;
+    scrollElement.scrollTo({ left, behavior: 'smooth' });
+  }, [activeFile, scrollableNodeRef]);
 
   // Handle tab close
   const handleTabClose = (e: MouseEvent<HTMLButtonElement>, key: number) => {

--- a/src/components/tree-view.tsx
+++ b/src/components/tree-view.tsx
@@ -42,26 +42,8 @@ const TreeView: FunctionComponent<TreeViewProps> = ({ title, childs }) => {
       setActiveFile(child.file.key);
       addActiveTab(child.file.key);
     }
-    setTimeout(() => {
-      //   const preCodeEditor = document.getElementsByClassName('pre-code-editor');
-      //   const spans = preCodeEditor[0]?.getElementsByTagName('span');
-      //   if (spans) {
-      //     for (let i = 0; i < spans.length; i += 1) {
-      //       const element = spans[i];
-      //       if (element?.textContent?.includes(child.lineText.word)) {
-      //         console.log(element);
-      //       }
-      //     }
-      //   }
-
-      const line = document.getElementById(`line-${child.lineNumber}`);
-      //   line?.setAttribute('style', 'color: RED');
-      setActiveLineNumber(child.lineNumber);
-      line?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    }, 10);
-
-    // console.log(child);
-    // console.log(line);
+    // Set active line number
+    setActiveLineNumber(child.lineNumber);
   };
 
   // Check if the search is active
@@ -76,7 +58,7 @@ const TreeView: FunctionComponent<TreeViewProps> = ({ title, childs }) => {
         onClick={() => setExpand((prev) => !prev)}
       >
         {expand ? (
-          <ChevronDownIcon className="h-4 w-4 cursor-pointer" />
+          <ChevronDownIcon className="h-4 w-4 cursor-pointer text-slate-100" />
         ) : (
           <ChevronRightIcon className="h-4 w-4 cursor-pointer" />
         )}


### PR DESCRIPTION
#3 Issue fixed.

Problem: When using `scrollIntoView({behavior:'smooth'})` on two elements at the same time it did not work.
[Example Project](https://codesandbox.io/s/dank-darkness-8g6vwr?file=/src/App.js:333-368)

- [x] Auto scroll to active tab with no bug. 
- [x] Auto scroll to active line when using search.